### PR TITLE
Fix gradle reference to SDK in example project

### DIFF
--- a/box-content-sample/build.gradle
+++ b/box-content-sample/build.gradle
@@ -26,5 +26,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.0.0'
-    compile project(':BoxSdkContent:box-content-sdk')
+    compile project(':box-content-sdk')
 }


### PR DESCRIPTION
The reference to ':BoxSdkContent:box-content-sdk' in the sample
project's build.gradle was invalid. Changing it to ':box-content-sdk'
fixes it. This was probably due to a repo rename.
