### PR TITLE
Update Content API Docs link to current URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Box Android Content SDK
 ===================
 
-This SDK makes it easy to use Box's [Content API](https://developers.box.com/docs/) in your Android projects.
+This SDK makes it easy to use Box's [Content API](https://box-content.readme.io/reference) in your Android projects.
 
 Quickstart
 ----------


### PR DESCRIPTION
As per note on https://developers.box.com/docs/ that "we will no longer be updating this current page after April 22, 2015".