### PR TITLE
Fixed flush for downloads 

### DIFF
--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/utils/ProgressOutputStream.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/utils/ProgressOutputStream.java
@@ -50,6 +50,13 @@ public class ProgressOutputStream extends OutputStream {
     @Override
     public void close() throws IOException {
         this.stream.close();
+        super.close();
+    }
+
+    @Override
+    public void flush() throws IOException {
+        this.stream.flush();
+        super.flush();
     }
 
     @Override


### PR DESCRIPTION
Fixes downloaded files not being renamed properly after completion when progress listener is attached