### PR TITLE
Fix for Box Android SDK issue 135

### DIFF
--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/auth/BoxAuthentication.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/auth/BoxAuthentication.java
@@ -378,12 +378,14 @@ public class BoxAuthentication {
                     try {
                         refreshInfo = session.getRefreshProvider().refreshAuthenticationInfo(info);
                     } catch (BoxException e) {
+                        mRefreshingTasks.remove(taskKey);
                         throw handleRefreshException(e, info);
                     }
                 } else if (mRefreshProvider != null) {
                     try {
                         refreshInfo = mRefreshProvider.refreshAuthenticationInfo(info);
                     } catch (BoxException e) {
+                        mRefreshingTasks.remove(taskKey);
                         throw handleRefreshException(e, info);
                     }
                 } else {
@@ -400,6 +402,7 @@ public class BoxAuthentication {
                     try {
                         refreshInfo = request.send();
                     } catch (BoxException e) {
+                        mRefreshingTasks.remove(taskKey);
                         throw handleRefreshException(e, info);
                     }
                 }


### PR DESCRIPTION
This is a fix for Box Android SDK issue 135 (https://github.com/box/box-android-sdk/issues/135). When a authentication request triggers an exception, we remove the task from BoxAuthentication.mRefreshingTasks in the catch block before re-throwing the exception. If this is not done, then subsequent requests will all fail because a task already exists which will return the failed result.