### PR TITLE
Fix bug in box iterator serialization

### DIFF
--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxIterator.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxIterator.java
@@ -112,9 +112,9 @@ public abstract class BoxIterator<E extends BoxJsonObject> extends BoxJsonObject
         }
         stream.writeUTF(iterator.toString());
         if (getEntries() == null){
-            stream.write(-1);
+            stream.writeInt(-1);
         } else {
-            stream.write(size());
+            stream.writeInt(size());
             JsonArray array = getPropertyAsJsonArray(FIELD_ENTRIES);
             for (int i=0; i < size(); i++){
                 stream.writeUTF(array.get(i).toString());


### PR DESCRIPTION
- We were using write instead of writeInt. If the value was 0, it was
  being interpreted as something else and readInt was failing.