### PR TITLE
HandleUnauthorizedScenarios

### DIFF
--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/BoxException.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/BoxException.java
@@ -185,6 +185,10 @@ public class BoxException extends Exception {
          */
         IP_BLOCKED("error_access_from_ip_not_allowed", HttpURLConnection.HTTP_FORBIDDEN),
         /**
+         * User has been deactivated.
+         */
+        UNAUTHORIZED("unauthorized", HttpURLConnection.HTTP_UNAUTHORIZED),
+        /**
          * An unknown exception has occurred.
          */
         OTHER("", 0);
@@ -254,7 +258,7 @@ public class BoxException extends Exception {
             ErrorType[] fatalTypes = new ErrorType[]{ErrorType.INVALID_GRANT_INVALID_TOKEN,
                     ErrorType.INVALID_GRANT_TOKEN_EXPIRED, ErrorType.ACCESS_DENIED, ErrorType.NO_CREDIT_CARD_TRIAL_ENDED,
                     ErrorType.SERVICE_BLOCKED, ErrorType.INVALID_CLIENT, ErrorType.UNAUTHORIZED_DEVICE,
-                    ErrorType.GRACE_PERIOD_EXPIRED, ErrorType.OTHER};
+                    ErrorType.GRACE_PERIOD_EXPIRED, ErrorType.UNAUTHORIZED,  ErrorType.OTHER};
             for (ErrorType fatalType : fatalTypes) {
                 if (type == fatalType) {
                     return true;

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/auth/BoxApiAuthentication.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/auth/BoxApiAuthentication.java
@@ -5,6 +5,7 @@ import com.box.androidsdk.content.BoxConstants;
 import com.box.androidsdk.content.models.BoxMDMData;
 import com.box.androidsdk.content.models.BoxSession;
 import com.box.androidsdk.content.BoxException;
+import com.box.androidsdk.content.requests.BoxHttpResponse;
 import com.box.androidsdk.content.requests.BoxRequest;
 import com.box.androidsdk.content.requests.BoxResponse;
 import com.box.androidsdk.content.utils.SdkUtils;
@@ -64,6 +65,14 @@ class BoxApiAuthentication extends BoxApi {
      */
     BoxRevokeAuthRequest revokeOAuth(String token, String clientId, String clientSecret) {
         BoxRevokeAuthRequest request = new BoxRevokeAuthRequest(mSession, getTokenRevokeUrl(), token, clientId, clientSecret);
+        request.setRequestHandler(new BoxRequest.BoxRequestHandler(request){
+
+            @Override
+            public boolean onException(BoxRequest request, BoxHttpResponse response, BoxException ex) throws BoxException.RefreshFailure {
+                // if a revoke request fails for any reason we do not want to retry it again after the user refreshes or logs in again.
+                return false;
+            }
+        });
         return request;
     }
 

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxSession.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxSession.java
@@ -482,7 +482,7 @@ public class BoxSession extends BoxObject implements BoxAuthentication.AuthListe
      */
     @Override
     public void onAuthCreated(BoxAuthentication.BoxAuthenticationInfo info) {
-        if (sameUser(info)) {
+        if (sameUser(info) || getUserId() == null) {
             BoxAuthentication.BoxAuthenticationInfo.cloneInfo(mAuthInfo, info);
             if (sessionAuthListener != null) {
                 sessionAuthListener.onAuthCreated(info);
@@ -710,7 +710,6 @@ public class BoxSession extends BoxObject implements BoxAuthentication.AuthListe
                         launchAuthUI();
                     }
                 }
-
                 return mSession;
             }
         }


### PR DESCRIPTION
Better handle error conditions which can cause user to get logged out. Also fixes a bug where user can immediately get logged out after logging in due to a previous unauthenticated request waiting.