### PR TITLE
Fix the text file corruption bug

### DIFF
--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestDownload.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestDownload.java
@@ -350,7 +350,7 @@ public abstract class BoxRequestDownload<E extends BoxObject, R extends BoxReque
                     } else {
                         output = getOutputStream(downloadInfo);
                     }
-                    SdkUtils.copyStream(response.getHttpURLConnection().getInputStream(), output);
+                    SdkUtils.copyStream(response.getBody(), output);
                 } catch (Exception e) {
                     throw new BoxException(e.getMessage(), e);
                 } finally {


### PR DESCRIPTION
- In case the response is encoded, ensure it is decoded before writing to
  a file