### PR TITLE
Fix the multipart request form order

### DIFF
--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestMultipart.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestMultipart.java
@@ -123,6 +123,11 @@ class BoxRequestMultipart extends BoxHttpRequest {
             connection.setDoOutput(true);
             this.outputStream = connection.getOutputStream();
 
+            for (Map.Entry<String, String> entry : this.fields.entrySet()) {
+                this.writePartHeader(new String[][]{{"name", entry.getKey()}});
+                this.writeOutput(entry.getValue());
+            }
+
             this.writePartHeader(new String[][] {{"name", "filename"}, {"filename", this.filename}},
                 "application/octet-stream");
 
@@ -139,11 +144,6 @@ class BoxRequestMultipart extends BoxHttpRequest {
 
             if (LOGGER.isLoggable(Level.FINE)) {
                 this.loggedRequest.append("<File Contents Omitted>");
-            }
-
-            for (Map.Entry<String, String> entry : this.fields.entrySet()) {
-                this.writePartHeader(new String[][] {{"name", entry.getKey()}});
-                this.writeOutput(entry.getValue());
             }
 
             this.writeBoundary();


### PR DESCRIPTION
According to https://docs.box.com/reference#upload-a-file, the file bytes should come after the JSON for best performance.