### PR TITLE
AND-7032 - New parameter for offline access only

### DIFF
--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/BoxApiFile.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/BoxApiFile.java
@@ -322,14 +322,15 @@ public class BoxApiFile extends BoxApi {
      *
      * @param target    target file to download to, target can be either a directory or a file
      * @param fileId    id of the file to download
+     * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
      * @return  request to download a file to a target file
      * @throws IOException throws FileNotFoundException if target file does not exist.
      */
-    public BoxRequestsFile.DownloadFile getDownloadRequest(File target, String fileId) throws IOException{
+    public BoxRequestsFile.DownloadFile getDownloadRequest(File target, String fileId, boolean offlineStore) throws IOException{
             if (!target.exists()){
                 throw new FileNotFoundException();
             }
-            BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(target, getFileDownloadUrl(fileId),mSession);
+            BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(target, getFileDownloadUrl(fileId),mSession, offlineStore);
             return request;
     }
 
@@ -338,14 +339,15 @@ public class BoxApiFile extends BoxApi {
      * This is used to download miscellaneous url assets for instance from the representations endpoint.
      * @param target    target file to download to, target can be either a directory or a file
      * @param url    url of the asset to download
+     * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
      * @return  request to download a file to a target file
      * @throws IOException throws FileNotFoundException if target file does not exist.
      */
-    public BoxRequestsFile.DownloadFile getDownloadUrlRequest(File target, String url) throws IOException{
+    public BoxRequestsFile.DownloadFile getDownloadUrlRequest(File target, String url, boolean offlineStore) throws IOException{
         if (!target.exists()){
             throw new FileNotFoundException();
         }
-        BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(target, url,mSession);
+        BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(target, url,mSession, offlineStore);
         return request;
     }
 
@@ -354,10 +356,11 @@ public class BoxApiFile extends BoxApi {
      *
      * @param outputStream outputStream to write file contents to.
      * @param fileId the file id to download.
+     * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
      * @return  request to download a file to an output stream
      */
-    public BoxRequestsFile.DownloadFile getDownloadRequest(OutputStream outputStream, String fileId) {
-            BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(outputStream, getFileDownloadUrl(fileId),mSession);
+    public BoxRequestsFile.DownloadFile getDownloadRequest(OutputStream outputStream, String fileId, boolean offlineStore) {
+            BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(outputStream, getFileDownloadUrl(fileId),mSession, offlineStore);
             return request;
     }
 
@@ -366,14 +369,15 @@ public class BoxApiFile extends BoxApi {
      *
      * @param target    target file to download to, target can be either a directory or a file
      * @param fileId    id of file to download the thumbnail of
+     * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
      * @return  request to download a thumbnail to a target file
      * @throws IOException throws FileNotFoundException if target file does not exist.
      */
-    public BoxRequestsFile.DownloadThumbnail getDownloadThumbnailRequest(File target, String fileId) throws IOException{
+    public BoxRequestsFile.DownloadThumbnail getDownloadThumbnailRequest(File target, String fileId, boolean offlineStore) throws IOException{
         if (!target.exists()){
             throw new FileNotFoundException();
         }
-        BoxRequestsFile.DownloadThumbnail request = new BoxRequestsFile.DownloadThumbnail(fileId, target, getThumbnailFileDownloadUrl(fileId), mSession);
+        BoxRequestsFile.DownloadThumbnail request = new BoxRequestsFile.DownloadThumbnail(fileId, target, getThumbnailFileDownloadUrl(fileId), mSession, offlineStore);
         return request;
     }
 
@@ -382,10 +386,11 @@ public class BoxApiFile extends BoxApi {
      *
      * @param outputStream outputStream to write file contents to.
      * @param fileId the file id to download.
+     * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
      * @return  request to download a file thumbnail
      */
-    public BoxRequestsFile.DownloadThumbnail getDownloadThumbnailRequest(OutputStream outputStream, String fileId) {
-        BoxRequestsFile.DownloadThumbnail request = new BoxRequestsFile.DownloadThumbnail(fileId, outputStream, getThumbnailFileDownloadUrl(fileId), mSession);
+    public BoxRequestsFile.DownloadThumbnail getDownloadThumbnailRequest(OutputStream outputStream, String fileId, boolean offlineStore) {
+        BoxRequestsFile.DownloadThumbnail request = new BoxRequestsFile.DownloadThumbnail(fileId, outputStream, getThumbnailFileDownloadUrl(fileId), mSession, offlineStore);
         return request;
     }
 

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/BoxApiUser.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/BoxApiUser.java
@@ -118,7 +118,7 @@ public class BoxApiUser extends BoxApi {
         if (!target.exists()){
             throw new FileNotFoundException();
         }
-        BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(userId, target, getAvatarDownloadUrl(userId), mSession);
+        BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(userId, target, getAvatarDownloadUrl(userId), mSession, true);
         return request;
     }
 
@@ -130,7 +130,7 @@ public class BoxApiUser extends BoxApi {
      * @return  request to download a file thumbnail
      */
     public BoxRequestsFile.DownloadFile getDownloadAvatarRequest(OutputStream outputStream, String userId) {
-        BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(userId, outputStream, getAvatarDownloadUrl(userId), mSession);
+        BoxRequestsFile.DownloadFile request = new BoxRequestsFile.DownloadFile(userId, outputStream, getAvatarDownloadUrl(userId), mSession, true);
         return request;
     }
 

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestDownload.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestDownload.java
@@ -43,6 +43,7 @@ public abstract class BoxRequestDownload<E extends BoxObject, R extends BoxReque
     protected String mId;
     private static final String QUERY_VERSION = "version";
     private static final String CONTENT_ENCODING_GZIP = "gzip";
+    private static final String QUERY_CONTENT_ACCESS = "log_content_access";
 
     /**
      * Creates a download request to an output stream with the default parameters.
@@ -52,8 +53,9 @@ public abstract class BoxRequestDownload<E extends BoxObject, R extends BoxReque
      * @param outputStream output stream to download the file to.
      * @param requestUrl   URL of the download endpoint.
      * @param session      the authenticated session that will be used to make the request with.
+     * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
      */
-    public BoxRequestDownload(String id, Class<E> clazz, final OutputStream outputStream, String requestUrl, BoxSession session) {
+    public BoxRequestDownload(String id, Class<E> clazz, final OutputStream outputStream, String requestUrl, BoxSession session, boolean offlineStore) {
         super(clazz, requestUrl, session);
         mId = id;
         mRequestMethod = Methods.GET;
@@ -61,6 +63,7 @@ public abstract class BoxRequestDownload<E extends BoxObject, R extends BoxReque
         mFileOutputStream = outputStream;
         this.setRequestHandler(new DownloadRequestHandler(this));
         mRequiresSocket = true;
+        mQueryMap.put(QUERY_CONTENT_ACCESS, Boolean.toString(offlineStore));
     }
 
     /**
@@ -70,16 +73,18 @@ public abstract class BoxRequestDownload<E extends BoxObject, R extends BoxReque
      * @param outputStream output stream to download the file to.
      * @param requestUrl   URL of the download endpoint.
      * @param session      the authenticated session that will be used to make the request with.
+     * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
      * @deprecated Please use the BoxRequestDownload constructor that takes in an id as this method may be removed in future releases
      */
     @Deprecated
-    public BoxRequestDownload(Class<E> clazz, final OutputStream outputStream, String requestUrl, BoxSession session) {
+    public BoxRequestDownload(Class<E> clazz, final OutputStream outputStream, String requestUrl, BoxSession session, boolean offlineStore) {
         super(clazz, requestUrl, session);
         mRequestMethod = Methods.GET;
         mRequestUrlString = requestUrl;
         mFileOutputStream = outputStream;
         this.setRequestHandler(new DownloadRequestHandler(this));
         mRequiresSocket = true;
+        mQueryMap.put(QUERY_CONTENT_ACCESS, Boolean.toString(offlineStore));
     }
 
     /**
@@ -90,8 +95,9 @@ public abstract class BoxRequestDownload<E extends BoxObject, R extends BoxReque
      * @param target     target file to download the file to.
      * @param requestUrl URL of the download endpoint.
      * @param session    the authenticated session that will be used to make the request with.
+     * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
      */
-    public BoxRequestDownload(String id, Class<E> clazz, final File target, String requestUrl, BoxSession session) {
+    public BoxRequestDownload(String id, Class<E> clazz, final File target, String requestUrl, BoxSession session, boolean offlineStore) {
         super(clazz, requestUrl, session);
         mId = id;
         mRequestMethod = Methods.GET;
@@ -99,6 +105,7 @@ public abstract class BoxRequestDownload<E extends BoxObject, R extends BoxReque
         mTarget = target;
         this.setRequestHandler(new DownloadRequestHandler(this));
         mRequiresSocket = true;
+        mQueryMap.put(QUERY_CONTENT_ACCESS, Boolean.toString(offlineStore));
     }
 
     /**
@@ -108,16 +115,18 @@ public abstract class BoxRequestDownload<E extends BoxObject, R extends BoxReque
      * @param target     target file to download the file to.
      * @param requestUrl URL of the download endpoint.
      * @param session    the authenticated session that will be used to make the request with.
+     * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
      * @deprecated Please use the BoxRequestDownload constructor that takes in an id as this method may be removed in future releases
      */
     @Deprecated
-    public BoxRequestDownload(Class<E> clazz, final File target, String requestUrl, BoxSession session) {
+    public BoxRequestDownload(Class<E> clazz, final File target, String requestUrl, BoxSession session, boolean offlineStore) {
         super(clazz, requestUrl, session);
         mRequestMethod = Methods.GET;
         mRequestUrlString = requestUrl;
         mTarget = target;
         this.setRequestHandler(new DownloadRequestHandler(this));
         mRequiresSocket = true;
+        mQueryMap.put(QUERY_CONTENT_ACCESS, Boolean.toString(offlineStore));
     }
 
     /**

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestsFile.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestsFile.java
@@ -691,9 +691,10 @@ public class BoxRequestsFile {
          * @param outputStream The output stream to download the file to
          * @param requestUrl URL of the download file endpoint
          * @param session The authenticated session that will be used to make the request with
+         * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
          */
-        public DownloadFile(String id, final OutputStream outputStream, String requestUrl, BoxSession session) {
-            super(id, BoxDownload.class, outputStream, requestUrl, session);
+        public DownloadFile(String id, final OutputStream outputStream, String requestUrl, BoxSession session, boolean offlineStore) {
+            super(id, BoxDownload.class, outputStream, requestUrl, session, offlineStore);
         }
 
         /**
@@ -702,11 +703,12 @@ public class BoxRequestsFile {
          * @param outputStream The output stream to download the file to
          * @param requestUrl URL of the download file endpoint
          * @param session The authenticated session that will be used to make the request with
+         * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
          * @deprecated Please use the DownloadFile constructor that takes in an id as this method may be removed in future releases
          */
         @Deprecated
-        public DownloadFile(final OutputStream outputStream, String requestUrl, BoxSession session) {
-            super(BoxDownload.class, outputStream, requestUrl, session);
+        public DownloadFile(final OutputStream outputStream, String requestUrl, BoxSession session, boolean offlineStore) {
+            super(BoxDownload.class, outputStream, requestUrl, session, offlineStore);
         }
 
         /**
@@ -716,9 +718,10 @@ public class BoxRequestsFile {
          * @param target The target file to download to
          * @param requestUrl URL of the download file endpoint
          * @param session The authenticated session that will be used to make the request with
+         * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
          */
-        public DownloadFile(String id, final File target, String requestUrl, BoxSession session) {
-            super(id, BoxDownload.class, target, requestUrl, session);
+        public DownloadFile(String id, final File target, String requestUrl, BoxSession session, boolean offlineStore) {
+            super(id, BoxDownload.class, target, requestUrl, session, offlineStore);
         }
 
         /**
@@ -727,11 +730,12 @@ public class BoxRequestsFile {
          * @param target Target file to download to
          * @param requestUrl URL of the download file endpoint
          * @param session The authenticated session that will be used to make the request with
+         * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
          * @deprecated Please use the DownloadFile constructor that takes in an id as this method may be removed in future releases
          */
         @Deprecated
-        public DownloadFile(final File target, String requestUrl, BoxSession session) {
-            super(BoxDownload.class, target, requestUrl, session);
+        public DownloadFile(final File target, String requestUrl, BoxSession session, boolean offlineStore) {
+            super(BoxDownload.class, target, requestUrl, session, offlineStore);
         }
     }
 
@@ -780,9 +784,10 @@ public class BoxRequestsFile {
          * @param outputStream The output stream to download the thumbnail to
          * @param requestUrl URL of the download thumbnail endpoint
          * @param session The authenticated session that will be used to make the request with
+         * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
          */
-        public DownloadThumbnail(String id, final OutputStream outputStream, String requestUrl, BoxSession session) {
-            super(id, BoxDownload.class, outputStream, requestUrl, session);
+        public DownloadThumbnail(String id, final OutputStream outputStream, String requestUrl, BoxSession session, boolean offlineStore) {
+            super(id, BoxDownload.class, outputStream, requestUrl, session, offlineStore);
         }
 
         /**
@@ -791,11 +796,12 @@ public class BoxRequestsFile {
          * @param outputStream The output stream to download the thumbnail to
          * @param requestUrl URL of the download thumbnail endpoint
          * @param session The authenticated session that will be used to make the request with
+         * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
          * @deprecated Please use the DownloadFile constructor that takes in an id as this method may be removed in future releases
          */
         @Deprecated
-        public DownloadThumbnail(final OutputStream outputStream, String requestUrl, BoxSession session) {
-            super(BoxDownload.class, outputStream, requestUrl, session);
+        public DownloadThumbnail(final OutputStream outputStream, String requestUrl, BoxSession session, boolean offlineStore) {
+            super(BoxDownload.class, outputStream, requestUrl, session, offlineStore);
         }
 
         /**
@@ -805,9 +811,10 @@ public class BoxRequestsFile {
          * @param target The target file to download thumbnail to
          * @param requestUrl URL of the download thumbnail endpoint
          * @param session The authenticated session that will be used to make the request with
+         * @param offlineStore flag to indicate this is a download only for offline store (not previewing)
          */
-        public DownloadThumbnail(String id, final File target, String requestUrl, BoxSession session) {
-            super(id, BoxDownload.class, target, requestUrl, session);
+        public DownloadThumbnail(String id, final File target, String requestUrl, BoxSession session, boolean offlineStore) {
+            super(id, BoxDownload.class, target, requestUrl, session, offlineStore);
         }
 
         /**
@@ -819,8 +826,8 @@ public class BoxRequestsFile {
          * @deprecated Please use the DownloadFile constructor that takes in an id as this method may be removed in future releases
          */
         @Deprecated
-        public DownloadThumbnail(final File target, String requestUrl, BoxSession session) {
-            super(BoxDownload.class, target, requestUrl, session);
+        public DownloadThumbnail(final File target, String requestUrl, BoxSession session, boolean offlineStore) {
+            super(BoxDownload.class, target, requestUrl, session, offlineStore);
         }
 
         /**


### PR DESCRIPTION
The server needs to differentiate when a file is accessed only to be available
for later access from the real file previewing. So a new parameter was made available
for that.