### PR TITLE
Remove error logging for createFromJson in auth

### DIFF
--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/auth/BoxAuthentication.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/auth/BoxAuthentication.java
@@ -776,12 +776,12 @@ public class BoxAuthentication {
 
             @Override
             public void createFromJson(String json) {
-                BoxLogUtils.e("trying to modify ImmutableBoxAuthenticationInfo", new RuntimeException());
+
             }
 
             @Override
             public void createFromJson(JsonObject object) {
-                BoxLogUtils.e("trying to modify ImmutableBoxAuthenticationInfo", new RuntimeException());
+
             }
 
             @Override


### PR DESCRIPTION
- createFromJson in BoxImmutableAuthenticationInfo is called in the
  object's normal lifecycle (from BoxJsonObject parent). Removing this
  logging to clean up logs