### PR TITLE
Context ContentProvider

### DIFF
--- a/box-content-sdk/src/main/AndroidManifest.xml
+++ b/box-content-sdk/src/main/AndroidManifest.xml
@@ -1,17 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.box.sdk.android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application>
+
         <activity
             android:name="com.box.androidsdk.content.auth.OAuthActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true" />
+
         <activity
             android:name="com.box.androidsdk.content.auth.BlockedIPErrorActivity"
             android:launchMode="singleInstance" />
+
+        <provider
+            android:authorities="com.box.androidsdk.content.utils.BoxContentProvider"
+            android:name="com.box.androidsdk.content.utils.BoxContentProvider"
+            android:exported="false"/>
+
     </application>
+
 </manifest>

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/utils/BoxContentProvider.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/utils/BoxContentProvider.java
@@ -1,0 +1,52 @@
+package com.box.androidsdk.content.utils;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.box.androidsdk.content.BoxConfig;
+
+
+public class BoxContentProvider extends ContentProvider {
+
+    @Override
+    public boolean onCreate() {
+        BoxConfig.APPLICATION_CONTEXT = getContext();
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection,
+                        @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection,
+                      @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+}


### PR DESCRIPTION
Add ContentProvider initialization step that will help solve case where Context reference is not present in BoxConfig field (issue: box/box-android-preview-sdk#23)

Depends on https://github.com/box/box-android-sdk/pull/405 