### PR TITLE
Fix a bug where some requestitem information is lost.

### DIFF
--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestItem.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestItem.java
@@ -39,6 +39,8 @@ public abstract class BoxRequestItem<E extends BoxJsonObject, R extends BoxReque
 
     protected BoxRequestItem(BoxRequestItem r) {
         super(r);
+        mId = r.getId();
+        mHintHeader = new StringBuffer(requestGetTaskCollaborators.mHintHeader.toString());
     }
 
     /**

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestItem.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequestItem.java
@@ -40,7 +40,7 @@ public abstract class BoxRequestItem<E extends BoxJsonObject, R extends BoxReque
     protected BoxRequestItem(BoxRequestItem r) {
         super(r);
         mId = r.getId();
-        mHintHeader = new StringBuffer(requestGetTaskCollaborators.mHintHeader.toString());
+        mHintHeader = new StringBuffer(r.mHintHeader.toString());
     }
 
     /**


### PR DESCRIPTION
Fixes a bug where when duplicating a request item via the special constructor id and mHintHeader can be lost.