### PR TITLE
Add support for the uploader display name field for Files and File Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+Changelog
+=========
+
+## Next Release
+
+__Breaking Changes:__
+
+__New Features and Enhancements:__
+
+- - Add support for the uploader display name field for Files and File Versions ([#424](https://github.com/box/box-android-sdk/pull/424))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ __Breaking Changes:__
 
 __New Features and Enhancements:__
 
-- - Add support for the uploader display name field for Files and File Versions ([#424](https://github.com/box/box-android-sdk/pull/424))
+- Add support for the uploader display name field for Files and File Versions ([#424](https://github.com/box/box-android-sdk/pull/424))

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxFile.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxFile.java
@@ -23,6 +23,7 @@ public class BoxFile extends BoxCollaborationItem {
     public static final String FIELD_IS_PACKAGE = "is_package";
     public static final String FIELD_COMMENT_COUNT = BoxConstants.FIELD_COMMENT_COUNT;
     public static final String FIELD_SIZE = BoxConstants.FIELD_SIZE;
+    public static final String FIELD_UPLOADER_DISPLAY_NAME = "uploader_display_name";
     public static final String FIELD_CONTENT_CREATED_AT = BoxConstants.FIELD_CONTENT_CREATED_AT;
     public static final String FIELD_CONTENT_MODIFIED_AT = BoxConstants.FIELD_CONTENT_MODIFIED_AT;
     public static final String FIELD_FILE_VERSION = "file_version";
@@ -42,6 +43,7 @@ public class BoxFile extends BoxCollaborationItem {
             FIELD_DESCRIPTION,
             FIELD_SIZE,
             FIELD_PATH_COLLECTION,
+            FIELD_UPLOADER_DISPLAY_NAME,
             FIELD_CREATED_BY,
             FIELD_MODIFIED_BY,
             FIELD_TRASHED_AT,
@@ -152,6 +154,13 @@ public class BoxFile extends BoxCollaborationItem {
     public Boolean getIsPackage() {
         return getPropertyAsBoolean(FIELD_IS_PACKAGE);
     }
+
+    /**
+     * Gets the user's name at the time of upload.
+     *
+     * @return the user's name at the time of upload.
+     */
+    public String getUploaderDisplayName() { return getPropertyAsString(FIELD_UPLOADER_DISPLAY_NAME); }
 
     @Override
     public Date getContentCreatedAt() {

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxFileVersion.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxFileVersion.java
@@ -19,6 +19,7 @@ public class BoxFileVersion extends BoxEntity {
     public static final String TYPE = "file_version";
     public static final String FIELD_NAME = "name";
     public static final String FIELD_SHA1 = "sha1";
+    public static final String FIELD_UPLOADER_DISPLAY_NAME= "uploader_display_name";
     public static final String FIELD_DELETED_AT = "deleted_at";
     public static final String FIELD_MODIFIED_BY = "modified_by";
     public static final String FIELD_CREATED_AT = "created_at";
@@ -29,6 +30,7 @@ public class BoxFileVersion extends BoxEntity {
             FIELD_NAME,
             FIELD_SIZE,
             FIELD_SHA1,
+            FIELD_UPLOADER_DISPLAY_NAME,
             FIELD_MODIFIED_BY,
             FIELD_CREATED_AT,
             FIELD_MODIFIED_AT,
@@ -50,6 +52,13 @@ public class BoxFileVersion extends BoxEntity {
     public String getName() {
         return getPropertyAsString(FIELD_NAME);
     }
+
+    /**
+     * Gets the user's name at the time of upload.
+     *
+     * @return the user's name at the time of upload.
+     */
+    public String getUploaderDisplayName() { return getPropertyAsString(FIELD_UPLOADER_DISPLAY_NAME); }
 
     /**
      * Gets the time the file version was created.

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxFileVersion.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/models/BoxFileVersion.java
@@ -19,7 +19,7 @@ public class BoxFileVersion extends BoxEntity {
     public static final String TYPE = "file_version";
     public static final String FIELD_NAME = "name";
     public static final String FIELD_SHA1 = "sha1";
-    public static final String FIELD_UPLOADER_DISPLAY_NAME= "uploader_display_name";
+    public static final String FIELD_UPLOADER_DISPLAY_NAME = "uploader_display_name";
     public static final String FIELD_DELETED_AT = "deleted_at";
     public static final String FIELD_MODIFIED_BY = "modified_by";
     public static final String FIELD_CREATED_AT = "created_at";

--- a/box-content-sdk/src/test/java/com/box/androidsdk/content/models/BoxFileTest.java
+++ b/box-content-sdk/src/test/java/com/box/androidsdk/content/models/BoxFileTest.java
@@ -63,7 +63,7 @@ public class BoxFileTest extends PowerMock {
     @Test
     public void testConstructorWithJsonObjectParameter() {
         // given
-        String version = "{\"type\":\"file_version\",\"id\":\"25141849133\",\"sha1\":\"7e88f301f2e3ce34bcbebabb37859e524178407b\"}";
+        String version = "{\"type\":\"file_version\",\"id\":\"25141849133\",\"sha1\":\"7e88f301f2e3ce34bcbebabb37859e524178407b\", \"uploader_display_name\": \"seanrose enterprise\"}";
         Date expectedDate = new Date();
         String formattedDate = BoxDateFormat.format(expectedDate);
         BoxFolder expectedParentFolder = BoxFolder.createFromId("20");
@@ -128,6 +128,7 @@ public class BoxFileTest extends PowerMock {
                 "\"content_modified_at\":\"" + formattedDate + "\"," +
                 "\"version_number\":\"1\"," +
                 "\"comment_count\":2," +
+                "\"uploader_display_name\":\"seanrose enterprise\"," +
                 "\"created_by\": " + userJson + ", " +
                 "\"modified_by\": " + userJson + ", " +
                 "\"owned_by\": " + userJson + ", " +
@@ -155,7 +156,8 @@ public class BoxFileTest extends PowerMock {
         DateUtil.assertSameDateSecondPrecision(expectedDate, file.getContentModifiedAt());
 
         Assert.assertEquals(file.getExtension(), "png");
-        Assert.assertEquals(expectedVersion, file.getFileVersion());
+        Assert.assertEquals(file.getFileVersion(), expectedVersion);
+        Assert.assertEquals(file.getFileVersion().getUploaderDisplayName(), "seanrose enterprise");
         Assert.assertFalse(file.getIsPackage());
         Assert.assertEquals(file.getRepresentations(), boxIteratorRepresentations);
         Assert.assertEquals(file.getSha1(), "134b65991ed521fcfe4724b7d814ab8ded5185dc");
@@ -165,6 +167,7 @@ public class BoxFileTest extends PowerMock {
         Assert.assertNotNull(file.getCollections());
         DateUtil.assertSameDateSecondPrecision(expectedDate, file.getCreatedAt());
         DateUtil.assertSameDateSecondPrecision(expectedDate, file.getModifiedAt());
+        Assert.assertEquals(file.getUploaderDisplayName(), "seanrose enterprise");
         Assert.assertEquals(file.getCreatedBy(), user);
         Assert.assertEquals(file.getDescription(), "a picture of tigers");
         Assert.assertEquals(file.getEtag(), "3");


### PR DESCRIPTION
Added the uploader display name field to the `BoxFile` and `BoxFileVersion` models