### PR TITLE
Add path parameter sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@ __Breaking Changes:__
 __New Features and Enhancements:__
 
 - Add support for the uploader display name field for Files and File Versions ([#424](https://github.com/box/box-android-sdk/pull/424))
-- Added path parameter sanitization ([#428](https://github.com/box/box-android-sdk/pull/428))
+- Add path parameter sanitization ([#428](https://github.com/box/box-android-sdk/pull/428))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ __Breaking Changes:__
 __New Features and Enhancements:__
 
 - Add support for the uploader display name field for Files and File Versions ([#424](https://github.com/box/box-android-sdk/pull/424))
+- Added path parameter sanitization ([#428](https://github.com/box/box-android-sdk/pull/428))

--- a/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequest.java
+++ b/box-content-sdk/src/main/java/com/box/androidsdk/content/requests/BoxRequest.java
@@ -43,11 +43,13 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+import java.net.MalformedURLException;
 
 /**
  * This class represents a request made to the Box server.
@@ -189,6 +191,13 @@ public abstract class BoxRequest<T extends BoxObject, R extends BoxRequest<T, R>
     public final T send() throws BoxException {
         Exception ex = null;
         T result = null;
+
+        // Pattern to check for relative paths
+        Pattern RELATIVE_PATH = Pattern.compile(".*\\/\\.+.*");
+        if (mRequestUrlString != null && RELATIVE_PATH.matcher(mRequestUrlString).matches()) {
+            throw new BoxException("An invalid path parameter passed. Relative path parameters cannot be passed.");
+        }
+
         try {
             result = onSend();
         } catch (Exception e){

--- a/box-content-sdk/src/test/java/com/box/androidsdk/content/requests/URLValidationTest.java
+++ b/box-content-sdk/src/test/java/com/box/androidsdk/content/requests/URLValidationTest.java
@@ -1,0 +1,40 @@
+package com.box.androidsdk.content.requests;
+
+import android.content.Context;
+
+import com.box.androidsdk.content.BoxApiFile;
+import com.box.androidsdk.content.BoxException;
+import com.box.androidsdk.content.models.BoxExpiringEmbedLinkFile;
+import com.box.androidsdk.content.testUtil.PowerMock;
+import com.box.androidsdk.content.testUtil.SessionUtil;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+@PrepareForTest({ BoxHttpResponse.class, BoxHttpRequest.class, BoxRequestsFile.class})
+public class URLValidationTest extends PowerMock {
+
+    @Mock
+    Context mMockContext;
+
+    @Test
+    public void failForInvalidURL() throws Exception {
+        {
+            final String invalidPathParameter = "/../";
+            final String expectedRequestUrl = "https://api.box.com/2.0/files/" + invalidPathParameter;
+            BoxApiFile fileApi = new BoxApiFile(SessionUtil.newMockBoxSession(mMockContext));
+            BoxRequestsFile.GetEmbedLinkFileInfo embedLinkRequest = fileApi.getEmbedLinkRequest(invalidPathParameter);
+            Assert.assertEquals(expectedRequestUrl, embedLinkRequest.mRequestUrlString);
+            try {
+                BoxExpiringEmbedLinkFile embedLinkFile = embedLinkRequest.send();
+            } catch (BoxException e) {
+                Assert.assertEquals("An invalid path parameter passed. Relative path parameters cannot be passed.", e.getMessage());
+                return;
+            }
+            Assert.fail("Never threw a BoxException");
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Added path parameter sanitization so no relative paths can be passed (i.e. `/../`). I did not include this logic in `buildURL()` in `BoxRequest` because though this is used for most requests, it is not the only `buildURL()` method. There are others in the SDK that are used for other requests. So I would have to include the logic in multiple methods if I chose the `buildURL()` route. The only method all requests used was the `send()` method in `BoxRequest`, so I included the sanitization logic here.