### PR TITLE
Drop Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,4 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-android.enableJetifier=true
 android.useAndroidX=true


### PR DESCRIPTION
Everything is already migrated to AndroidX. Jetifier can be dropped.