### PR TITLE
Fix cross-app scripting vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ## Next Release
 
 __Breaking Changes:__
+- Fix cross-app scripting vulnerability by removing Activity export of OAuthActivity ([#440](https://github.com/box/box-android-sdk/pull/440))
 
 __New Features and Enhancements:__
 

--- a/box-content-sdk/src/main/AndroidManifest.xml
+++ b/box-content-sdk/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         <activity
             android:name="com.box.androidsdk.content.auth.OAuthActivity"
             android:configChanges="orientation|screenSize"
-            android:exported="true" />
+            android:exported="false" />
 
         <activity
             android:name="com.box.androidsdk.content.auth.BlockedIPErrorActivity"


### PR DESCRIPTION
### Issue Link :link:

- https://github.com/box/box-android-sdk/issues/439

### Goals :soccer:

- Fix cross-app scripting vulnerability in `OAuthActivity`

### Implementation Details :construction:

- Google Play Store's recommends an option to fix this security vulnerability, which is to not export the affected WebView Activity (`OAuthActivity`). See here for more details on the recommendations: https://support.google.com/faqs/answer/9084685?hl=en-GB
- [Here is the original change](https://github.com/box/box-android-sdk/pull/34) where `OAuthActivity` was initially exported. The intention of the original fix was to prevent OAuthActivity from being recreated upon screen reorientation. This fix is achieved with the addition of `android:configChanges="orientation|screenSize"`, whereas exporting the activity is not required.

### Testing Details :mag:

- Verified that OAuthActivity is not being recreated upon screen rotation
- Ran tests
